### PR TITLE
FEAT(Docker): Add dockerfile and a script to auto-gen docker compose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:trixie-slim
+
+ARG TARGETARCH
+ARG VERSION=latest
+ENV BIN_NAME=smart-agent
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PORT=9099
+ENV TOKEN=
+ENV INTERVAL=60s
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt update && \
+    apt install -y --no-install-recommends \
+    bash \
+    tzdata \
+    smartmontools \
+    curl \
+    gettext \
+    ca-certificates && \
+    update-ca-certificates
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY config.yaml.template entrypoint.sh download.sh /app/
+
+RUN if [ "$TARGETARCH" != "amd64" ] && [ "$TARGETARCH" != "arm64" ]; then \
+    echo "❌ Error: Unsupported architecture: $TARGETARCH. Only amd64 and arm64 are allowed."; \
+    exit 1; \
+else \
+    bash download.sh ${BIN_NAME} ${TARGETARCH} ${VERSION}; \
+    rm download.sh; \
+    fi
+
+ENTRYPOINT /app/entrypoint.sh

--- a/docker/config.yaml.template
+++ b/docker/config.yaml.template
@@ -1,0 +1,3 @@
+port: ${PORT}
+token: ${TOKEN}
+scan_interval: ${INTERVAL}

--- a/docker/download.sh
+++ b/docker/download.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+BIN_NAME="${1:?Error: bin_name is required}"
+PLATFORM="${2:?Error: platform is required}"
+VERSION="${3:?Error: release version is required}"
+
+echo ${BIN_NAME}
+echo ${PLATFORM}
+echo ${VERSION}
+
+if [ "x$VERSION" = "xlatest" ]; then
+  VERSION=$(curl -sSf "https://api.github.com/repos/DAB-LABS/smart-sniffer/releases/latest" \
+    | grep '"tag_name"' | head -1 | sed 's/.*"v\([^"]*\)".*/\1/')
+  if [ -z "$VERSION" ]; then
+    fail "Could not determine latest version. Set VERSION=x.y.z manually."
+  fi
+fi
+echo ${VERSION}
+
+
+curl -sSfL -o ${BIN_NAME} https://github.com/DAB-LABS/smart-sniffer/releases/download/v${VERSION}/smartha-agent-linux-${PLATFORM}
+chmod +x ${BIN_NAME}
+sed -i "s/BIN_NAME/${BIN_NAME}/g" entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+envsubst < config.yaml.template > config.yaml
+./BIN_NAME

--- a/docker/gen_service.sh
+++ b/docker/gen_service.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# --- Configuration ---
+OUTPUT_FILE="docker-compose.yaml"
+AGENT_PORT=${PORT:-9099}
+AGENT_INTERVAL=${INTERVAL:-60s}
+AGENT_TOKEN=${TOKEN:-""}
+# Generate a random 5-digit suffix (e.g., smart-agent-54321)
+RANDOM_ID=$(shuf -i 10000-99999 -n 1)
+AGENT_HOSTNAME="smart-agent-$RANDOM_ID"
+
+echo "🔍 Scanning system for physical disks and required capabilities..."
+
+# 1. Identify all physical disks
+DISK_LIST=$(lsblk -dnio NAME,TYPE | grep 'disk')
+DISK_DEVICES=$(echo "$DISK_LIST" | awk '{printf "      - \"/dev/%s:/dev/%s\"\n", $1, $1}')
+
+if [ -z "$DISK_DEVICES" ]; then
+    echo "❌ Error: No physical disks found!"
+    exit 1
+fi
+
+# 2. Determine required capabilities based on disk types
+CAP_ADD_BLOCK="    cap_add:"
+HAS_SATA=false
+HAS_NVME=false
+
+if echo "$DISK_LIST" | grep -q '^sd'; then
+    HAS_SATA=true
+    CAP_ADD_BLOCK="${CAP_ADD_BLOCK}
+	# Required for SATA/SAS SMART data
+	- SYS_RAWIO"
+fi
+
+if echo "$DISK_LIST" | grep -q 'nvme'; then
+    HAS_NVME=true
+    CAP_ADD_BLOCK="${CAP_ADD_BLOCK}
+	# Required for NVMe SMART data
+	- SYS_ADMIN"
+fi
+
+# 3. Construct optional TOKEN environment variable
+ENV_TOKEN_LINE=""
+if [ -n "$AGENT_TOKEN" ]; then
+    ENV_TOKEN_LINE="      - TOKEN=$AGENT_TOKEN"
+fi
+
+echo "📝 Generating $OUTPUT_FILE (Security: Capabilities mode)..."
+
+# Generate YAML template
+cat << YAML > $OUTPUT_FILE
+services:
+  smart-agent:
+    build: .
+    container_name: smart-agent
+    hostname: $AGENT_HOSTNAME
+${CAP_ADD_BLOCK}
+    # required for mDNS auto discovery
+    # or you can use macvlan with home assistant
+    network_mode: host
+    environment:
+      # INTERVAL, TOKEN and PORT for service configuration
+      - INTERVAL=$AGENT_INTERVAL
+      - PORT=$AGENT_PORT
+${ENV_TOKEN_LINE}
+    devices:
+$DISK_DEVICES
+    restart: unless-stopped
+YAML
+
+# Clean up empty lines
+sed -i '/^[[:space:]]*$/d' $OUTPUT_FILE
+
+echo "✅ Generation complete!"
+echo "--------------------------------"
+echo "Detected: SATA=$HAS_SATA, NVMe=$HAS_NVME"
+echo "--------------------------------"
+cat $OUTPUT_FILE
+echo "--------------------------------"


### PR DESCRIPTION
as pr review comments:
1. add arm platform support
2. auto discover new release if no build arg VERSION specified
4. INTERVAL env variable changed to '60s' from '60' to support '1m', '1h' format
5. add gen_service.sh to auto generate `docker-compose.yaml`, with disks auto discovered and permissions necessary

No `.dockerignore` needed by now, since the `Dockerfile` only pick few files specified into image, but not copy any directories. 