### PR TITLE
Fix two editor UX bugs: scroll jump and storage filter

### DIFF
--- a/frontend/smart-sniffer-card/smart-sniffer-card.js
+++ b/frontend/smart-sniffer-card/smart-sniffer-card.js
@@ -1049,6 +1049,15 @@ class SmartSnifferCard extends HTMLElement {
       drives = drives.filter(d => cfg.drives.includes(d.device_id));
     }
 
+    // When a drive or agent filter is active, restrict filesystems to agents
+    // that appear in the filtered drive list so storage tiles stay in sync
+    // with the drive chips.
+    let filesystems = this._filesystems;
+    if (cfg.agents.length > 0 || cfg.drives.length > 0) {
+      const allowedAgents = new Set(drives.map(d => d.agent_name));
+      filesystems = filesystems.filter(fs => allowedAgents.has(fs.agent_name));
+    }
+
     // Loading detection.
     const isLoading = this._isLoading(drives);
 
@@ -1056,7 +1065,7 @@ class SmartSnifferCard extends HTMLElement {
     card.appendChild(this._renderHeader(drives, this._agentCount, isLoading));
 
     // Empty state.
-    if (drives.length === 0 && this._filesystems.length === 0 && !isLoading) {
+    if (drives.length === 0 && filesystems.length === 0 && !isLoading) {
       card.appendChild(this._renderEmpty());
       return;
     }
@@ -1084,9 +1093,9 @@ class SmartSnifferCard extends HTMLElement {
     // inline within each agent's group, so there is no separate storage
     // section anymore. The section renders if EITHER drives or filesystems
     // exist (filesystem-only agents are valid).
-    const haveStorage = cfg.show_storage && this._filesystems.length > 0;
+    const haveStorage = cfg.show_storage && filesystems.length > 0;
     if (drives.length > 0 || haveStorage) {
-      card.appendChild(this._renderDrivesSection(drives, driveAgentOrder));
+      card.appendChild(this._renderDrivesSection(drives, driveAgentOrder, filesystems));
     }
 
     // Scroll handling after a re-render. Two cases:
@@ -1307,7 +1316,7 @@ class SmartSnifferCard extends HTMLElement {
      The agentOrder argument comes from _computeAgentOrder so the same
      hierarchy is honored even for agents that have no drives (filesystem-
      only agents). */
-  _renderDrivesSection(drives, agentOrder) {
+  _renderDrivesSection(drives, agentOrder, filesystems) {
     const cfg = this._config;
     const visible = (cfg.show_ok === false)
       ? drives.filter(d => d.state !== "healthy" && d.state !== "cached")
@@ -1344,7 +1353,7 @@ class SmartSnifferCard extends HTMLElement {
     // Group filesystems by agent name (when storage display is enabled).
     const filesystemsByAgent = {};
     if (cfg.show_storage) {
-      for (const fs of this._filesystems) {
+      for (const fs of filesystems) {
         const key = fs.agent_name || "agent";
         if (!filesystemsByAgent[key]) filesystemsByAgent[key] = [];
         filesystemsByAgent[key].push(fs);

--- a/frontend/smart-sniffer-card/smart-sniffer-card.js
+++ b/frontend/smart-sniffer-card/smart-sniffer-card.js
@@ -1882,6 +1882,13 @@ class SmartSnifferCardEditor extends HTMLElement {
     const cfg = this._config;
     const hass = this._hass;
 
+    // Save scroll positions of check-lists before the full innerHTML replacement,
+    // so frequent hass updates don't jump the list back to the top mid-scroll.
+    const savedScrolls = [];
+    this.shadowRoot.querySelectorAll(".check-list").forEach(el => {
+      savedScrolls.push(el.scrollTop);
+    });
+
     // Discover drive-device options for the filter checklist.
     const driveOptions = [];
     const agentOptions = [];
@@ -2005,6 +2012,11 @@ class SmartSnifferCardEditor extends HTMLElement {
             <div class="hint">Leave all unchecked to show every drive.</div>`
         }
       </div>`;
+
+    // Restore scroll positions so a hass-triggered re-render doesn't reset the list.
+    this.shadowRoot.querySelectorAll(".check-list").forEach((el, i) => {
+      if (savedScrolls[i] != null) el.scrollTop = savedScrolls[i];
+    });
 
     this.shadowRoot.querySelectorAll("[data-key]").forEach(el => {
       el.addEventListener("change", () => {


### PR DESCRIPTION
## Summary

Two bugs fixed in the card editor and card renderer.

### 1. Editor drive list jumps to top on scroll

The editor's `set hass()` re-renders on every HA state update by replacing the entire `shadowRoot.innerHTML`, destroying and recreating the `.check-list` scroll containers and resetting their `scrollTop` to zero. Users couldn't scroll down to select lower drives because the list snapped back before they could click.

**Fix:** Save the `scrollTop` of all `.check-list` elements before the `innerHTML` replacement and restore them immediately after.

### 2. Storage tiles ignore drive/agent filter

When `cfg.drives` or `cfg.agents` filters were active, drive chips correctly filtered to the selected set — but disk usage tiles were still rendered for all agents, because `_renderDrivesSection` always iterated over `this._filesystems` directly, bypassing the filter entirely.

**Fix:** After applying the drive/agent filter in `_render()`, compute a filtered `filesystems` list restricted to agents whose name appears in the filtered drive list. Thread this through to `_renderDrivesSection` as a parameter and update the `haveStorage` and empty-state checks to use the filtered list too.

## Test plan

- [x] Open the card editor with many drives — scroll partway down the list and confirm it stays put between HA state updates
- [x] Check a drive checkbox and confirm the list doesn't jump after the `config-changed` event fires
- [x] Configure the card with `cfg.drives` set to a subset of drives on one agent — confirm only that agent's storage tiles appear
- [x] Configure with `cfg.agents` set to a specific agent — confirm other agents' storage tiles are hidden
- [x] With no filters active, confirm all storage tiles still appear as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)