### PR TITLE
feat: add get_drive_data HA action for AI-powered drive health analysis

### DIFF
--- a/custom_components/smart_sniffer/__init__.py
+++ b/custom_components/smart_sniffer/__init__.py
@@ -61,6 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             return {
                 "agent": {
+                    "name": health.entry.title,
                     "host": health.host,
                     "port": health.port,
                     "version": health.data.get("version"),

--- a/custom_components/smart_sniffer/__init__.py
+++ b/custom_components/smart_sniffer/__init__.py
@@ -63,7 +63,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "model": drive_data.get("model"),
                     "serial": drive_data.get("serial"),
                     "protocol": drive_data.get("protocol"),
-                    "device_path": drive_data.get("device") or (drive_data.get("smart_data") or {}).get("device", {}).get("name"),
+                    "device_path": drive_data.get("device_path"),
                     "attention": {
                         "state": state,
                         "severity": severity,
@@ -85,7 +85,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             return {
                 "agent": {
-                    "name": health.entry.title,
+                    "name": health.config_entry.title,
                     "host": health.host,
                     "os": health.data.get("os"),
                     "uptime": health.data.get("uptime_seconds"),

--- a/custom_components/smart_sniffer/__init__.py
+++ b/custom_components/smart_sniffer/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
 
+from .attention import evaluate_attention
 from .const import DOMAIN, FILESYSTEMS_KEY, SERVICE_GET_DRIVE_DATA
 from .coordinator import AgentHealthCoordinator, SmartSnifferCoordinator
 
@@ -53,22 +54,45 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             coord = domain_data[entry_id]["coordinator"]
             health = domain_data[entry_id]["health_coordinator"]
 
-            drives: dict[str, Any] = {
-                drive_id: drive_data
-                for drive_id, drive_data in coord.data.items()
-                if not drive_id.startswith("_")
-            }
+            drives: dict[str, Any] = {}
+            for drive_id, drive_data in coord.data.items():
+                if drive_id.startswith("_"):
+                    continue
+                state, severity, reasons = evaluate_attention(drive_data)
+                drives[drive_id] = {
+                    "model": drive_data.get("model"),
+                    "serial": drive_data.get("serial"),
+                    "protocol": drive_data.get("protocol"),
+                    "device_path": drive_data.get("device") or (drive_data.get("smart_data") or {}).get("device", {}).get("name"),
+                    "attention": {
+                        "state": state,
+                        "severity": severity,
+                        "reasons": reasons,
+                    },
+                    "smart_data": drive_data.get("smart_data"),
+                }
+
+            raw_filesystems: list[dict[str, Any]] = coord.data.get(FILESYSTEMS_KEY, [])
+            filesystems = [
+                {
+                    "mountpoint": fs.get("mountpoint"),
+                    "total_bytes": fs.get("total_bytes"),
+                    "used_bytes": fs.get("used_bytes"),
+                    "use_percent": fs.get("use_percent"),
+                }
+                for fs in raw_filesystems
+            ]
 
             return {
                 "agent": {
                     "name": health.entry.title,
                     "host": health.host,
-                    "port": health.port,
-                    "version": health.data.get("version"),
                     "os": health.data.get("os"),
-                    "connected": health.data.get("connected"),
+                    "uptime": health.data.get("uptime_seconds"),
+                    "version": health.data.get("version"),
                 },
                 "drives": drives,
+                "filesystems": filesystems,
             }
 
         hass.services.async_register(

--- a/custom_components/smart_sniffer/__init__.py
+++ b/custom_components/smart_sniffer/__init__.py
@@ -9,12 +9,16 @@ proactive Attention Needed assessment.
 from __future__ import annotations
 
 import logging
+from typing import Any
+
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.exceptions import ServiceValidationError
 
-from .const import DOMAIN
+from .const import DOMAIN, FILESYSTEMS_KEY, SERVICE_GET_DRIVE_DATA
 from .coordinator import AgentHealthCoordinator, SmartSnifferCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,6 +41,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Register the get_drive_data service once per domain.
+    if not hass.services.has_service(DOMAIN, SERVICE_GET_DRIVE_DATA):
+        async def handle_get_drive_data(call: ServiceCall) -> dict[str, Any]:
+            entry_id: str = call.data["config_entry_id"]
+            domain_data = hass.data.get(DOMAIN, {})
+            if entry_id not in domain_data:
+                raise ServiceValidationError(
+                    f"No SMART Sniffer entry found with ID: {entry_id}"
+                )
+            coord = domain_data[entry_id]["coordinator"]
+            health = domain_data[entry_id]["health_coordinator"]
+
+            drives: dict[str, Any] = {
+                drive_id: drive_data
+                for drive_id, drive_data in coord.data.items()
+                if not drive_id.startswith("_")
+            }
+
+            return {
+                "agent": {
+                    "host": health.host,
+                    "port": health.port,
+                    "version": health.data.get("version"),
+                    "os": health.data.get("os"),
+                    "connected": health.data.get("connected"),
+                },
+                "drives": drives,
+            }
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_GET_DRIVE_DATA,
+            handle_get_drive_data,
+            schema=vol.Schema({vol.Required("config_entry_id"): str}),
+            supports_response=SupportsResponse.ONLY,
+        )
+
     # Reload the integration when options are changed via the UI.
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
@@ -48,6 +89,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, SERVICE_GET_DRIVE_DATA)
     return unload_ok
 
 

--- a/custom_components/smart_sniffer/const.py
+++ b/custom_components/smart_sniffer/const.py
@@ -21,3 +21,6 @@ AGENT_RELEASES_URL = "https://github.com/DAB-LABS/smart-sniffer/releases"
 # Key used in coordinator data dict to store filesystem info.
 # Underscore prefix avoids collision with drive ID keys.
 FILESYSTEMS_KEY = "_filesystems"
+
+# Service name for the get_drive_data action.
+SERVICE_GET_DRIVE_DATA = "get_drive_data"

--- a/custom_components/smart_sniffer/services.yaml
+++ b/custom_components/smart_sniffer/services.yaml
@@ -1,0 +1,13 @@
+get_drive_data:
+  name: Get Drive Data
+  description: >
+    Returns the full cached SMART data for all drives monitored by a SMART Sniffer
+    agent. Useful for passing raw drive health data to an AI for analysis.
+  fields:
+    config_entry_id:
+      name: Config Entry
+      description: The SMART Sniffer agent to query.
+      required: true
+      selector:
+        config_entry:
+          integration: smart_sniffer

--- a/custom_components/smart_sniffer/strings.json
+++ b/custom_components/smart_sniffer/strings.json
@@ -59,6 +59,18 @@
       "unknown": "An unexpected error occurred."
     }
   },
+  "services": {
+    "get_drive_data": {
+      "name": "Get Drive Data",
+      "description": "Returns the full cached SMART data for all drives monitored by a SMART Sniffer agent. Useful for passing raw drive health data to an AI for analysis.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config Entry",
+          "description": "The SMART Sniffer agent to query."
+        }
+      }
+    }
+  },
   "issues": {
     "agent_outdated": {
       "title": "SMART Sniffer: Update agent on {hostname} (v{current_version} → v{min_version})",

--- a/custom_components/smart_sniffer/translations/en.json
+++ b/custom_components/smart_sniffer/translations/en.json
@@ -59,6 +59,18 @@
       "unknown": "An unexpected error occurred."
     }
   },
+  "services": {
+    "get_drive_data": {
+      "name": "Get Drive Data",
+      "description": "Returns the full cached SMART data for all drives monitored by a SMART Sniffer agent. Useful for passing raw drive health data to an AI for analysis.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config Entry",
+          "description": "The SMART Sniffer agent to query."
+        }
+      }
+    }
+  },
   "issues": {
     "agent_outdated": {
       "title": "SMART Sniffer: Update agent on {hostname} (v{current_version} → v{min_version})",


### PR DESCRIPTION
## Summary

- Adds a `smart_sniffer.get_drive_data` HA action that returns enriched SMART data for all drives monitored by a given agent, closes #37
- Registers once per domain, unregisters when the last config entry is removed
- Returns a structured response with agent metadata, per-drive attention evaluation, and filesystem usage — served from cache with no extra HTTP calls

### Response shape

```yaml
agent:
  name: SMART Sniffer (hostname)
  host: 192.168.x.x
  os: linux
  uptime: 139159        # seconds
  version: v0.5.13

drives:
  <drive-id>:
    model: ...
    serial: ...
    protocol: ATA | NVMe
    device_path: /dev/sda
    attention:
      state: "NO" | "MAYBE" | "YES" | "UNSUPPORTED"
      severity: none | warning | critical
      reasons:
        - "Reallocated Sector Count: 8 (expected 0)"
    smart_data: { ... }   # full smartctl -a --json output

filesystems:
  - mountpoint: /rpool
    total_bytes: 982235955200
    used_bytes: 147753611264
    use_percent: 15.0
```

### Why this shape

The AI receives our attention interpretation alongside the raw data — it doesn't need to re-derive thresholds to give a useful report. Filesystem usage ties disk health to actual space pressure on the host.

## Use case

Enables passing full SMART data to an AI via `conversation.process` for holistic drive health analysis beyond the fixed attention thresholds. Example automation:

```yaml
action: smart_sniffer.get_drive_data
data:
  config_entry_id: "your_entry_id"
response_variable: smart_data
```

Then pass `smart_data | to_json` to any configured HA conversation agent (OpenAI, Gemini, Ollama, etc.).

## Test plan

- [x] Action appears in Developer Tools → Actions with correct description and `config_entry` picker
- [x] Returns full `smart_data` for all drives on the specified agent
- [x] `attention` block correct for healthy drives (NO/none), degraded drives (YES/critical with reasons)
- [x] `device_path` resolves for ATA (`/dev/sda`) and NVMe (`/dev/nvme0`) drives
- [x] `filesystems` list populated when agent reports filesystem data
- [x] `agent.name` reflects the config entry title (e.g. `SMART Sniffer (myhostname)`)
- [x] `ServiceValidationError` raised for unknown `config_entry_id`
- [x] Tested against multiple agents (Proxmox PVE, Synology NAS) with ATA and NVMe drives
- [x] Service description renders correctly in HA UI (`translations/en.json` updated)
- [ ] Service unregistered when last config entry is removed — not tested

## Review fixes

- `health.config_entry.title` — fixed `AttributeError` from incorrect `health.entry.title`
- `device_path` — simplified to `drive_data.get("device_path")` matching the agent API key directly
- `translations/en.json` — added `services` block so the action description renders in the HA UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)