### PR TITLE
fix(card): prevent Unicode BiDi reversal of Windows drive paths

### DIFF
--- a/frontend/smart-sniffer-card/smart-sniffer-card.js
+++ b/frontend/smart-sniffer-card/smart-sniffer-card.js
@@ -878,7 +878,10 @@ class SmartSnifferCard extends HTMLElement {
 
   _friendlyMount(mp) {
     if (mp === "/") return "Root (/)";
-    return mp;
+    // Append a zero-width LTR mark so trailing neutral chars (e.g. "\" in "C:\")
+    // are anchored LTR inside the direction:rtl container used for left-truncation,
+    // preventing the BiDi algorithm from reversing them (which displays "C:\" as "\:C").
+    return mp + "‎";
   }
 
   _buildDrive(hass, dev, devId, entityIds, agentDevicesByEntry, agentNameByEntry) {


### PR DESCRIPTION
## Summary

- Windows drive root paths like `C:\` were displaying as `\:C` in the disk usage tile
- Root cause: the `direction:rtl` CSS used for left-side path truncation causes the Unicode BiDi algorithm to resolve trailing neutral characters (`\` and `:`) as RTL when no strong LTR character follows them
- Fix: append a zero-width LTR mark (U+200E) in `_friendlyMount()` to anchor trailing neutral characters as LTR — invisible in rendered output, doesn't affect the raw mountpoint shown in the tooltip

## Test plan

- [x] On a Windows agent, verify disk usage tiles show `C:\` correctly (not `\:C`)
- [x] Verify Unix paths (e.g. `/`, `/home/user`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)